### PR TITLE
Add automatic visible/invisible voice channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Brown Esports Discord bot
+
 This is a private bot for [Brown Esports](https://brownesports.org). Most of this bot is hardcoded, feel free to @ me on our Discord before adapting this code for your server.
 
 ## Contributing
+
 This project's official formatter is **Prettier**.
 This project's official package manager is **Yarn**.
 
@@ -10,14 +12,21 @@ To contribute, clone the repository, execute `yarn`, copy `.env.example` into `.
 Every time you pull from the repository, execute `yarn`, then `yarn start`.
 
 ## Current Feature Branches:
-*None (Git Flow not configured as I'm working solo)*
+
+_None (Git Flow not configured as I'm working solo)_
 
 ## Updates
-- 6/9/2020 - Ported code from an older bot, including broadcast, announcements, changelogs, etc
-- 6/10/2020 - Created the "fragile counting game", a game where the streak can be broken
+
+-   6/9/2020 - Ported code from an older bot, including broadcast, announcements, changelogs, etc
+-   6/10/2020 - Created the "fragile counting game", a game where the streak can be broken
+-   7/10/2021 - Private voice channels with a prefix become visible only when they are not empty
 
 ## Contributors
+
 ### Isaac Kim
-- Working on fixing bugs in the counting games (6/10/2020)
+
+-   Working on fixing bugs in the counting games (6/10/2020)
+
 ### Salvador Brandi
-- Bot Introductions to competetive games channels (8/27/2020)
+
+-   Bot Introductions to competitive games channels (8/27/2020)

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,6 @@
 prefix: "^"
 privateChannelPrefix: "🔒"
+privateChannelSuffix: "᲼"
 countinggamechannels:
   - id: "720133492939161661"
   - id: "720323796111851572"

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,5 @@
 prefix: "^"
-privateChannelPrefix: "🔒"
-privateChannelSuffix: "᲼"
+privateChannelString: "🔒"
 countinggamechannels:
   - id: "720133492939161661"
   - id: "720323796111851572"

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,5 @@
 prefix: "^"
+privateChannelPrefix: "🔒"
 countinggamechannels:
   - id: "720133492939161661"
   - id: "720323796111851572"

--- a/index2.js
+++ b/index2.js
@@ -748,7 +748,8 @@ client.on("voiceStateUpdate", (oldUser, newUser) => {
 
   if (
     oldChannel &&
-    oldChannel.name.startsWith(config.privateChannelPrefix) &&
+    (oldChannel.name.startsWith(config.privateChannelPrefix) ||
+      oldChannel.name.endsWith(config.privateChannelSuffix)) &&
     oldChannel.members.size === 0
   ) {
     // User left a channel, and the channel is now empty
@@ -763,7 +764,8 @@ client.on("voiceStateUpdate", (oldUser, newUser) => {
 
   if (
     newChannel &&
-    newChannel.name.startsWith(config.privateChannelPrefix) &&
+    (newChannel.name.startsWith(config.privateChannelPrefix) ||
+      newChannel.name.endsWith(config.privateChannelSuffix)) &&
     newChannel.members.size === 1
   ) {
     // User joined a channel, and is the first to join

--- a/index2.js
+++ b/index2.js
@@ -748,8 +748,7 @@ client.on("voiceStateUpdate", (oldUser, newUser) => {
 
   if (
     oldChannel &&
-    (oldChannel.name.startsWith(config.privateChannelPrefix) ||
-      oldChannel.name.endsWith(config.privateChannelSuffix)) &&
+    oldChannel.name.includes(config.privateChannelString) &&
     oldChannel.members.size === 0
   ) {
     // User left a channel, and the channel is now empty
@@ -764,8 +763,7 @@ client.on("voiceStateUpdate", (oldUser, newUser) => {
 
   if (
     newChannel &&
-    (newChannel.name.startsWith(config.privateChannelPrefix) ||
-      newChannel.name.endsWith(config.privateChannelSuffix)) &&
+    newChannel.name.includes(config.privateChannelString) &&
     newChannel.members.size === 1
   ) {
     // User joined a channel, and is the first to join

--- a/index2.js
+++ b/index2.js
@@ -748,7 +748,7 @@ client.on("voiceStateUpdate", (oldUser, newUser) => {
 
   if (
     oldChannel &&
-    oldChannel.name.startsWith("🔒") &&
+    oldChannel.name.startsWith(config.privateChannelPrefix) &&
     oldChannel.members.size === 0
   ) {
     // User left a channel, and the channel is now empty
@@ -763,7 +763,7 @@ client.on("voiceStateUpdate", (oldUser, newUser) => {
 
   if (
     newChannel &&
-    newChannel.name.startsWith("🔒") &&
+    newChannel.name.startsWith(config.privateChannelPrefix) &&
     newChannel.members.size === 1
   ) {
     // User joined a channel, and is the first to join

--- a/index2.js
+++ b/index2.js
@@ -772,7 +772,7 @@ client.on("voiceStateUpdate", (oldUser, newUser) => {
     newChannel.updateOverwrite(
       newChannel.guild.roles.everyone,
       {
-        VIEW_CHANNEL: true,
+        VIEW_CHANNEL: null,
       },
       "Voice channel made visible after user joined"
     );

--- a/index2.js
+++ b/index2.js
@@ -742,4 +742,39 @@ client.on("messageReactionAdd", (reaction, user) => {
   }
 });
 
+client.on("voiceStateUpdate", (oldUser, newUser) => {
+  const oldChannel = oldUser.channel;
+  const newChannel = newUser.channel;
+
+  if (
+    oldChannel &&
+    oldChannel.name.startsWith("🔒") &&
+    oldChannel.members.size === 0
+  ) {
+    // User left a channel, and the channel is now empty
+    oldChannel.updateOverwrite(
+      oldChannel.guild.roles.everyone,
+      {
+        VIEW_CHANNEL: false,
+      },
+      "Voice channel made invisible after last user left"
+    );
+  }
+
+  if (
+    newChannel &&
+    newChannel.name.startsWith("🔒") &&
+    newChannel.members.size === 1
+  ) {
+    // User joined a channel, and is the first to join
+    newChannel.updateOverwrite(
+      newChannel.guild.roles.everyone,
+      {
+        VIEW_CHANNEL: true,
+      },
+      "Voice channel made visible after user joined"
+    );
+  }
+});
+
 client.login(process.env.DISCORDBOTTOKEN);


### PR DESCRIPTION
Implements voice channels that are by default invisible to unauthorized members, but the channel becomes visible to everyone if at least one member is in the voice channel.  The voice channel becomes invisible again after the last member leaves.

This feature is customizable by using the `privateChannelPrefix` option in `config.yml`.  By default, channels that are prefixed with 🔒 have this feature.